### PR TITLE
Added support for require('laravel-elixir-browserify-official');

### DIFF
--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -5,7 +5,7 @@ var elixir = require('laravel-elixir'),
   buffer = require('vinyl-buffer'),
   babelify = require('babelify'),
   uglify = require('gulp-uglify');
-
+require('laravel-elixir-browserify-official');
 elixir.config.js.browserify.plugins.push(
     {
         name: 'factor-bundle',


### PR DESCRIPTION
Browserify is not officially supported in the latest Elixir. So I had to add JerryWay's package to add support for it.

https://www.npmjs.com/package/laravel-elixir-browserify-official

PS: A pull request on react-spark-js repo https://github.com/darrenmerrett/react-spark-js/pull/1